### PR TITLE
Fixed map options in config without webmap

### DIFF
--- a/src/app/config.js
+++ b/src/app/config.js
@@ -12,13 +12,11 @@ define(['esri/InfoTemplate'], function(InfoTemplate) {
       // see: https://developers.arcgis.com/javascript/jsapi/map-amd.html#map1
       mapOptions: {
         scrollWheelZoom: true
-      },
       // uncomment these options if you do not use a webmap id
-      // options: {
-      //    basemap: 'gray',
-      //    center: [-117.1, 33.6],
-      //    zoom: 9,
-      // }
+      //  ,basemap: 'gray'
+      //  ,center: [-117.1, 33.6]
+      //  ,zoom: 9
+      },
       //
       // uncomment these section if you do not use a webmap id
       // operationalLayers: [{


### PR DESCRIPTION
I was initially confused when I tried to create a map instead of a webmap. Nothing was happening. I determined that the options values in the config.js file needed to be directly under the mapOptions key. Now, anyone who wants to use a map instead of a webmap just needs to comment the itemId and uncomment the rest of the mapOptions. 

The leading commas in mapOptions are placed that way to avoid lint issues. I don't know if there's a better way.