### PR TITLE
responsive sidebar

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
       },
       dev: {
         options: {
-          beautify: true
+          beautify: false
         },
         dest: 'src/esri'
       }

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -1,24 +1,56 @@
 define(['esri/InfoTemplate'], function(InfoTemplate) {
   return {
-    map: {
-      // if id is set, map will load from a webmap
-      // comment this out if you want to load layers from config below
-      itemId: '4778fee6371d4e83a22786029f30c7e1',
 
-      // NOTE: if using a webmap (e.g. via id)
-      // this is the options sent to arcgisUtils.createMap()
+    mapControls: {
+      // **********************************************
+      // Example configuration when using a webmap
+      // **********************************************
+
+      // example web maps:
+      // web map from bootstrap map demo, see
+      // http://esri.github.io/bootstrap-map-js/demo/jquery/webmap.html
+      // itemId: '68f12b304ad8495eb77fb55243c0ccc2',
+
+      // SoCal running trails
+      // GPX tracks embeded in web map as feature collections
+      // itemId: 'cbb968b3854e4e4fac3f95c30ca41b38',
+
+      // Los Angeles Bike Paths - KML layer of bike paths
+      // itemId: '78ca84d1f2534d3496e63fa80240d4f3',
+
+      // web maps from ArcGIS JSAPI sample pages
+      // NOTE: both require a dijit theme (i.e. claro)
+      // to support the dojox/charting dijits in the popups
+
+      // Tapastry Segments - dynamic map servce w/ dojox/chart in popup
+      // itemId: '4778fee6371d4e83a22786029f30c7e1',
+
+      // mobile web map example, see:
+      // https://developers.arcgis.com/javascript/jssamples/mobile_arcgis.html
+      itemId: '1e79439598494713b553f990a4040886',
+
+      // NOTE: this is the options sent to arcgisUtils.createMap()
       // see: https://developers.arcgis.com/javascript/jsapi/esri.arcgis.utils-amd.html#createmap
-      // otherwise it is the options sent to new Map()
-      // see: https://developers.arcgis.com/javascript/jsapi/map-amd.html#map1
-      mapOptions: {
-        scrollWheelZoom: true
-      // uncomment these options if you do not use a webmap id
-      //  ,basemap: 'gray'
-      //  ,center: [-117.1, 33.6]
-      //  ,zoom: 9
+      options: {
+        mapOptions: {
+          sliderPosition: 'bottom-right'
+        }
       },
-      //
-      // uncomment these section if you do not use a webmap id
+
+      // **********************************************
+      // Example configuration when NOT using a webmap
+      // and loading layers from the settings in this config
+      // **********************************************
+
+      // NOTE: this is the options sent to new Map()
+      // see: https://developers.arcgis.com/javascript/jsapi/map-amd.html#map1
+      // options: {
+      //   basemap: 'gray',
+      //   center: [-117.1, 33.6],
+      //   zoom: 9,
+      //   sliderPosition: 'bottom-right'
+      // },
+
       // operationalLayers: [{
       //   type: 'feature',
       //   url: 'http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Earthquakes/Since_1970/MapServer/0',
@@ -57,6 +89,10 @@ define(['esri/InfoTemplate'], function(InfoTemplate) {
       // TODO: add basemaps
       // basemaps: {},
 
+      // set the id of a node to place the legend
+      // comment this out if you don't want to show legend
+      legendNodeId: 'mapLegend',
+
       // Add config parameters for each map widget you want to include
       // The map reference will get appended to the options
       // To accept default options just pass empty object {}
@@ -81,7 +117,9 @@ define(['esri/InfoTemplate'], function(InfoTemplate) {
         }
       }
     },
-    navBar: {
+
+    // about modal
+    aboutModal: {
       moreInfoUrl: 'https://github.com/Esri/dojo-bootstrap-map-js'
     }
   };

--- a/src/app/layout/AboutModal.js
+++ b/src/app/layout/AboutModal.js
@@ -1,0 +1,42 @@
+define([
+  'dojo/_base/declare',
+
+  'dijit/_WidgetBase',
+  'dijit/_TemplatedMixin',
+
+  'dojo/text!./templates/AboutModal.html',
+  'dojo/i18n!./nls/strings'
+], function(
+  declare,
+  _WidgetBase, _TemplatedMixin,
+  template, strings
+) {
+
+  return declare([_WidgetBase, _TemplatedMixin], {
+    templateString: template,
+    strings: strings,
+
+    _setMoreInfoUrlAttr: {
+      node: 'moreInfoNode',
+      type: 'attribute',
+      attribute: 'href'
+    },
+
+    _setTitleAttr: {
+      node: 'titleNode',
+      type: 'innerHTML'
+    },
+
+    _setContentAttr: {
+      node: 'contentNode',
+      type: 'innerHTML'
+    },
+
+    // get default title/content from i18n strings
+    postCreate: function() {
+      this.set('title', strings.modalAboutTitle);
+      this.set('content', '<p>' + strings.modalAboutContent + '</p>');
+    }
+
+   });
+});

--- a/src/app/layout/templates/AboutModal.html
+++ b/src/app/layout/templates/AboutModal.html
@@ -1,0 +1,12 @@
+<div class="modal-dialog">
+  <div class="modal-content">
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+      <h4 data-dojo-attach-point="titleNode" class="modal-title"></h4>
+    </div>
+    <div class="modal-body">
+      <div data-dojo-attach-point="contentNode"></div>
+      <p><a data-dojo-attach-point="moreInfoNode" target="_blank">${strings.modalAboutMoreInfo}</a>
+    </div>
+  </div>
+</div>

--- a/src/app/layout/templates/NavBar.html
+++ b/src/app/layout/templates/NavBar.html
@@ -1,51 +1,35 @@
-<div>
-  <div class="navbar navbar-inverse navbar-fixed-top">
-    <div class="container">
-      <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </button>
-        <a class="navbar-brand" href="#">${strings.appTitle}</a>
-      </div>
-      <div class="collapse navbar-collapse">
-        <ul class="nav navbar-nav">
-          <li class="active dropdown basemap-list">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown">${strings.navBasemaps} <b class="caret"></b></a>
-            <!-- TODO: build this dynamically from config -->
-            <ul class="dropdown-menu">
-              <li><a href="#">Streets</a></li>
-              <li><a href="#">Imagery</a></li>
-              <li><a href="#">National Geographic</a></li>
-              <li><a href="#">Topographic</a></li>
-              <li><a href="#">Gray</a></li>
-              <li class="divider"></li>
-              <li><a href="#">Open Street Map</a></li>
-              <li class="divider"></li>
-              <li><a href="#">MapBox Space</a></li>
-              <li><a href="#">Water Color</a></li>
-              <li><a href="#">Pinterest</a></li>
-            </ul>
-          </li>
-          <li><a href="#about">${strings.navAbout}</a></li>
-        </ul>
-      </div><!--/.nav-collapse -->
-    </div>
+<div class="container-fluid">
+  <div class="navbar-header">
+    <button data-dojo-attach-point="sidebarToggleButton" type="button" class="navbar-toggle navbar-toggle-left">
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+    <a data-dojo-attach-point="titleNode" class="navbar-brand" href="#"></a>
+    <button data-dojo-attach-point="collapseMenuToggleButton" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+      <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
+    </button>
   </div>
-  <!-- about modal -->
-  <div class="modal fade about-modal" style="display: none;" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-          <h4 class="modal-title">${strings.modalAboutTitle}</h4>
-        </div>
-        <div class="modal-body">
-          <p>${strings.modalAboutContent}</p>
-          <p><a data-dojo-attach-point="moreInfoNode" target="_blank">${strings.modalAboutMoreInfo}</a>
-        </div>
-      </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
+  <div class="collapse navbar-collapse">
+    <ul class="nav navbar-nav">
+      <li class="active dropdown basemap-list">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">${strings.navBasemaps} <b class="caret"></b></a>
+        <!-- TODO: build this dynamically from config -->
+        <ul class="dropdown-menu">
+          <li><a href="#">Streets</a></li>
+          <li><a href="#">Imagery</a></li>
+          <li><a href="#">National Geographic</a></li>
+          <li><a href="#">Topographic</a></li>
+          <li><a href="#">Gray</a></li>
+          <li class="divider"></li>
+          <li><a href="#">Open Street Map</a></li>
+          <li class="divider"></li>
+          <li><a href="#">MapBox Space</a></li>
+          <li><a href="#">Water Color</a></li>
+          <li><a href="#">Pinterest</a></li>
+        </ul>
+      </li>
+      <li><a href="#about">${strings.navAbout}</a></li>
+    </ul>
   </div>
 </div>

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,32 +1,72 @@
-define(['dojo/topic',
+define([
+  'dojo/query',
+  'dojo/dom',
+  'dojo/dom-class',
+  'dojo/dom-style',
+  'dojo/topic',
 
   './config',
-  './mapping/Map',
+  './mapping/MapControls',
   './layout/NavBar',
+  './layout/AboutModal',
+
+  'dojo-bootstrap/Modal',
 
   'dojo/domReady!'],
 function(
-  topic,
-  config, Map, NavBar
+  query, dom, domClass, domStyle, topic,
+  config, MapControls, NavBar, AboutModal
 ) {
   'use strict';
   var app = {};
 
-  // start map widget
-  app.map = new Map(config.map, 'mapNode');
-  app.map.startup();
+  // start map
+  app.mapControls = new MapControls(config.mapControls, 'mapControls');
+  app.mapControls.startup();
 
-  // start nav widget
-  app.navBar = new NavBar(config.navBar, 'navBarNode');
+  // start nav
+  app.navBar = new NavBar({}, 'navBar');
   app.navBar.startup();
 
-  // set up topics
-  topic.subscribe('basemap/set', function(args) {
-    app.map.setBasemap(args.basemap);
+  // start about modal
+  app.aboutModal = new AboutModal(config.aboutModal, 'aboutModal');
+  app.aboutModal.startup();
+
+  // responsive sidebar
+  app.sidebar = dom.byId('sidebar');
+
+  // app topics
+  // set app title and about text when loading from web map
+  topic.subscribe('webmap/load', function(args) {
+    var item;
+    if (!args.itemInfo && args.itemInfo.item) {
+      return;
+    }
+    item = args.itemInfo.item;
+    app.aboutModal.set('title', item.title);
+    app.aboutModal.set('content', item.description);
+    app.navBar.set('title', item.title);
   });
 
-  // set page title
-  window.document.title = app.navBar.strings.appTitle;
+  // set the basemap
+  topic.subscribe('basemap/set', function(args) {
+    app.mapControls.setBasemap(args.basemap);
+  });
+
+  // toggle the sidebar
+  topic.subscribe('sidebar/toggle', function() {
+    if (!app.sidebar) {
+      return;
+    }
+    // make sure sidebar is same height as the map
+    domStyle.set(app.sidebar, 'height', app.mapControls.map.height + 'px');
+    domClass.toggle(window.document.body, 'sidebar-open');
+  });
+
+  // show the about modal
+  topic.subscribe('about/show', function() {
+    query('.about-modal').modal('show');
+  });
 
   return app;
 });

--- a/src/app/mapping/templates/Map.html
+++ b/src/app/mapping/templates/Map.html
@@ -1,6 +1,6 @@
 <div>
   <div data-dojo-attach-point="mapNode">
-  	<div data-dojo-attach-point="homeNode"></div>
+    <div data-dojo-attach-point="homeNode"></div>
     <div data-dojo-attach-point="searchNode"></div>
     <div data-dojo-attach-point="locateNode"></div>
   </div>

--- a/src/app/resources/app.css
+++ b/src/app/resources/app.css
@@ -1,39 +1,142 @@
+/* top nav */
 body {
   padding-top: 50px;
 }
 
-body > .container {
-  padding-bottom: 20px;
+.navbar-toggle {
+  padding: 8px 10px;
 }
 
-table {
-  border-collapse: ;
-  border-spacing: ;
+.navbar-toggle-left {
+  float: left;
+  margin-left: 15px;
+  margin-right: 8px;
+  padding: 10px 10px;
 }
 
-.starter-template {
-  padding: 40px 15px;
-  text-align: center;
+.navbar-toggle .glyphicon {
+  color: #fff;
+  font-size: 14px;
+}
+
+/* no margins or padding around map */
+.container-map, .container-map .col-map {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.container-map .row-map {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+/* map widgets */
+.HomeButton {
+  position: absolute;
+  top: 15px;
+  left: 15px;
+  z-index: 30;
+  margin: 2px 0; /*needed to line up w/ geocoder */
 }
 
 .locate-button {
   position: absolute;
-  top: 162px;
-  left: 16px;
-  z-index: 50;
+  top: 15px;
+  left: 55px;
+  z-index: 30;
+  margin: 2px 0; /*needed to line up w/ geocoder */
 }
 
 .geocoder {
   display: block;
   position: absolute;
-  z-index: 2;
-  top: 65px;
+  z-index: 30;
+  top: 15px;
   right: 15px;
 }
 
-.HomeButton {
-  position: absolute;
-  top: 130px;
-  left: 16px;
-  z-index: 50;
+.esriSimpleSliderBR {
+  right: 15px;
+}
+
+/* override defaults set in bootstrapmap.css */
+.simpleGeocoder .esriGeocoderContainer {
+  width: 210px;
+}
+.esriSimpleSlider {
+  top: auto;
+  left: auto;
+}
+
+/*
+  NOTE: this only inlcuded to disable popup tooltips
+  in the sample web maps from ArcGIS Online.
+  To enable them for those web maps, you must
+  include the dijit claro theme and remove these overrrides.
+*/
+.dijitTooltip {
+  display: none;
+}
+.esriViewPopup .caption {
+  display: none;
+}
+
+/* responsive styles for mobile */
+@media (max-width:767px) {
+
+  /* off canvas sidebar */
+  #sidebar {
+    position: fixed;
+    top: 55px;
+    left: -260px;
+    z-index: 100;
+    font-size: small;
+    width: 260px;
+    /*
+      default to iPhone 5 portrait height, but
+      this will be overwritten by app
+    */
+    height: 320px;
+    overflow: auto;
+
+    /* mimic col styles */
+    padding-left: 15px;
+    padding-right: 15px;
+    background-color: #fff;
+
+    -webkit-transition: left .5s ease-in-out;
+    -moz-transition: left .5s ease-in-out;
+    -o-transition: left .5s ease-in-out;
+    transition: left .5s ease-in-out;
+  }
+
+  /* don't wrap title */
+  a.navbar-brand {
+    white-space: nowrap;
+    overflow-x: hidden;
+  }
+
+  /* overlay sidebar */
+  .sidebar-open #sidebar {
+    left: 0;
+  }
+
+  /* move down slider smaller attribution */
+  .esriSimpleSliderBR {
+    bottom: 30px;
+  }
+
+  /* hide scalebar */
+  .esriScalebar {
+    display: none;
+  }
+}
+
+@media (max-width:600px) {
+  /* smaller title */
+  a.navbar-brand {
+    padding-left: 5px;
+    padding-right: 5px;
+    max-width: 200px;
+  }
 }

--- a/src/app/resources/main.css
+++ b/src/app/resources/main.css
@@ -1,4 +1,3 @@
-@import url("../../dijit/themes/claro/claro.css");
 @import url("../../esri/css/esri.css");
 @import url("../../bootstrap-map-js/src/css/bootstrapmap.css");
 @import url("app.css");

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,6 @@
 
     <!-- get dependency styles from CDN instead of locally -->
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/dijit/themes/claro/claro.css">
     <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     <link rel="stylesheet" type="text/css" href="//esri.github.io/bootstrap-map-js/dist/css/bootstrapmap.min.css">
     <!-- get app styles locally -->
@@ -25,9 +24,30 @@
       <script src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
   </head>
-  <body class="claro">
-    <div id="navBarNode"></div>
-    <div id="mapNode"></div>
+  <body>
+    <!-- top nav -->
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div id="navBar"></div>
+    </div>
+    <div class="container-fluid container-map">
+      <div class="row row-map">
+        <!-- the map -->
+        <div class="col-xs-12 col-sm-9 col-sm-push-3 col-lg-10 col-lg-push-2 col-map">
+          <div id="mapControls"></div>
+        </div>
+        <!-- responsive sidebar -->
+        <div class="col-xs-12 col-sm-3 col-sm-pull-9 col-lg-2 col-lg-pull-10">
+          <div id="sidebar">
+            <h4>Legend</h4>
+             <div id="mapLegend"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- about modal -->
+    <div class="modal fade about-modal" style="display: none;" aria-hidden="true">
+      <div id="aboutModal"></div>
+    </div>
     <script>
       window.dojoConfig = {
         async: true,
@@ -46,6 +66,7 @@
         ]
       };
     </script>
+    <!-- NOTE: we're not using compact b/c we're using esri/dijit -->
     <script src="//js.arcgis.com/3.11"></script>
     <script>require([ 'app/main' ]);</script>
   </body>

--- a/src/unbuilt.html
+++ b/src/unbuilt.html
@@ -24,9 +24,30 @@
       <script src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
   </head>
-  <body class="claro">
-    <div id="navBarNode"></div>
-    <div id="mapNode"></div>
+  <body>
+    <!-- top nav -->
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div id="navBar"></div>
+    </div>
+    <div class="container-fluid container-map">
+      <div class="row row-map">
+        <!-- the map -->
+        <div class="col-xs-12 col-sm-9 col-sm-push-3 col-lg-10 col-lg-push-2 col-map">
+          <div id="mapControls"></div>
+        </div>
+        <!-- responsive sidebar -->
+        <div class="col-xs-12 col-sm-3 col-sm-pull-9 col-lg-2 col-lg-pull-10">
+          <div id="sidebar">
+            <h4>Legend</h4>
+             <div id="mapLegend"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- about modal -->
+    <div class="modal fade about-modal" style="display: none;" aria-hidden="true">
+      <div id="aboutModal"></div>
+    </div>
     <script>
       window.dojoConfig = {
         async: true,


### PR DESCRIPTION
- sidebar goes off canvas on mobile and hamburger button brings it in as an overlay
- about modal is it's own widget now and renamed mapping/Map to mapping/MapControls for clarity
- fixed responsive resizing issues caused by creating bootstrap map from
  dom node instead of id
- using web map from mobile web map example and added more example ids to
  config as comments
- when web map is loaded, it sets the page title and about text
- new responsive layout for map widgets works well down to iPhone 4

resolves #24